### PR TITLE
This cleans up how variants work

### DIFF
--- a/bin/courseware
+++ b/bin/courseware
@@ -27,6 +27,10 @@ optparse = OptionParser.new { |opts|
         cmdlineopts[:renderer] = opt.to_sym
     end
 
+    opts.on("-f", "--file FILE", "Presentation file. Defaults to 'showoff.json'.") do |opt|
+        cmdlineopts[:presfile] = opt
+    end
+
     opts.on("-d", "--debug", "Display debugging messages") do
         cmdlineopts[:debug] = true
     end
@@ -56,7 +60,6 @@ config.merge!(cmdlineopts)
 config[:templates]            ||= 'git@github.com:puppetlabs/courseware-templates.git'
 config[:cachedir]             ||= '~/.courseware'
 config[:stylesheet]           ||= 'courseware.css'
-config[:presfile]             ||= 'showoff.json'
 config[:renderer]             ||= :wkhtmltopdf
 config[:output]               ||= 'pdf'
 config[:collector]            ||= 'http://puppetlabs.com/training/issues?s='
@@ -71,6 +74,14 @@ config[:pdf][:password]       ||= 'default'
 config[:pdf][:protected]      ||= true
 config[:pdf][:watermark]      ||= false
 config[:pdf][:license]        ||= nil
+
+# Validating obsolete slides is special because we have to load all variants;
+# nonetheless, we do need *something* valid there, so drop in a dummy value.
+if ARGV == ['validate', 'obsolete']
+  config[:presfile] ||= 'showoff.json'
+else
+  config[:presfile] ||= Courseware.choose_variant
+end
 
 # expand out all path shortcuts in one single place.
 [ :cachedir ].each do |path|

--- a/lib/courseware.rb
+++ b/lib/courseware.rb
@@ -45,7 +45,6 @@ class Courseware
       :course  => @manager.coursename,
       :prefix  => @manager.prefix,
       :version => @repository.current(@manager.prefix),
-      :variant => Courseware.choose_variant,
     }
     Courseware::Printer.new(@config, opts) do |printer|
       subject.each do |item|

--- a/lib/courseware/help.rb
+++ b/lib/courseware/help.rb
@@ -49,6 +49,8 @@ class Courseware
                   obsolete: Lists all unreferenced images and slides. This reference checks
                             all slides and all CSS stylesheets. Case sensitive.
 
+                            Note: This validator will validate all course variants.
+
                    missing: Lists all slides that are missing. Note that this does not check
                             for missing image files yet. Case sensitive.
 

--- a/lib/courseware/manager.rb
+++ b/lib/courseware/manager.rb
@@ -15,23 +15,7 @@ class Courseware::Manager
     @warnings   = 0
     @errors     = 0
 
-    if File.exists?(@config[:presfile])
-      showoff     = JSON.parse(File.read(@config[:presfile]))
-      @coursename = showoff['name']
-      @prefix     = showoff['name'].gsub(' ', '_')
-      @sections   = showoff['sections'].map do |entry|
-        next entry if entry.is_a? String
-        next nil unless entry.is_a? Hash
-        next nil unless entry.include? 'include'
-
-        file = entry['include']
-        path = File.dirname(file)
-        data = JSON.parse(File.read(file))
-
-        data.map { |source| "#{path}/#{source}" }
-      end.flatten
-
-    end
+    @coursename, @prefix, @sections = Courseware.parse_showoff(@config[:presfile])
   end
 
   def releasenotes
@@ -133,7 +117,6 @@ private
       :course  => @coursename,
       :prefix  => @prefix,
       :version => version,
-      :variant => Courseware.choose_variant,
     }
   end
 

--- a/lib/courseware/manager/validators.rb
+++ b/lib/courseware/manager/validators.rb
@@ -1,6 +1,12 @@
 class Courseware::Manager
 
   def obsolete
+    # We need to get all slides from all variants to determine what's obsolete.
+    allsections = Dir.glob('*.json').collect do |variant|
+      coursename, prefix, sections = Courseware.parse_showoff(variant)
+      sections
+    end.flatten.uniq
+
     puts "Obsolete images:"
     Dir.glob('**/_images/*') do |file|
       next if File.symlink? file
@@ -16,7 +22,7 @@ class Courseware::Manager
       next if File.symlink? file
       next if File.directory? file
       next if file =~ /^_.*$|^[^\/]*$/
-      next if @sections.include? file
+      next if allsections.include? file
 
       puts "  * #{file}"
       @warnings += 1

--- a/lib/courseware/printer.rb
+++ b/lib/courseware/printer.rb
@@ -6,8 +6,8 @@ class Courseware::Printer
     @course  = opts[:course]  or raise 'Course is a required option'
     @prefix  = opts[:prefix]  or raise 'Prefix is a required option'
     @version = opts[:version] or raise 'Version is a required option'
-    @varfile = opts[:variant] or raise 'Variant is a required option'
 
+    @varfile = config[:presfile] or raise 'Presentation file is not set properly!'
     @variant = File.basename(@varfile, '.json') unless @varfile == 'showoff.json'
 
     raise unless can_print?
@@ -123,7 +123,7 @@ class Courseware::Printer
     begin
       # Until showoff static knows about -f, we have to schlup around files
       if @variant
-        FileUtils.mv 'showoff.json', 'showoff.json.tmp'
+        FileUtils.mv 'showoff.json', '.showoff.json.tmp'
         FileUtils.cp @varfile, 'showoff.json'
       end
 
@@ -134,7 +134,7 @@ class Courseware::Printer
         FileUtils.cp('cobrand.png', File.join('static', 'image', 'cobrand.png'))
       end
     ensure
-      FileUtils.mv('showoff.json.tmp', 'showoff.json') if File.exist? 'showoff.json.tmp'
+      FileUtils.mv('.showoff.json.tmp', 'showoff.json') if File.exist? 'showoff.json.tmp'
     end
   end
 

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -87,6 +87,26 @@ class Courseware
     variants[idx]
   end
 
+  # TODO: I'm not happy with this being here, but I don't see a better place for it just now
+  def self.parse_showoff(filename)
+    showoff    = JSON.parse(File.read(filename))
+    coursename = showoff['name']
+    prefix     = showoff['name'].gsub(' ', '_')
+    sections   = showoff['sections'].map do |entry|
+      next entry if entry.is_a? String
+      next nil unless entry.is_a? Hash
+      next nil unless entry.include? 'include'
+
+      file = entry['include']
+      path = File.dirname(file)
+      data = JSON.parse(File.read(file))
+
+      data.map { |source| "#{path}/#{source}" }
+    end.flatten.compact
+
+    return coursename, prefix, sections
+  end
+
   def self.get_component(initial)
     puts 'The component ID for this course can be found at:'
     puts ' * https://tickets.puppetlabs.com/browse/COURSES/?selectedTab=com.atlassian.jira.jira-projects-plugin:components-panel'


### PR DESCRIPTION
This unifies how variants work instead of special-casing it within the
`printer`  subclass. It means that the proper json will be looked at
anywhere we use it. This makes things like the validators work.

There is one exception. When we validate obsolete slides, we can't look
at only a single variant. We need to look at the conglomerate of **all**
variants in order to determine if a slide is not referenced in any of
them.

There's still a significant amount of cleanup and refactoring that I
want to do, but I'm going to hold off on that until we get a little more
experience building the variants.