### PR TITLE
courseware manager updates for it to run headless

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 # Courseware Manager
 ## Release Notes
 
+### v0.5.1
+* Support modular presentations
+* Allow watermarked PDF files via metadata in showoff
+* Open file storage links during release process
+
 ### v0.5.0 (Public release)
 * First public release
     * Not for general consumption, merely for ease of distribution.

--- a/bin/courseware
+++ b/bin/courseware
@@ -31,6 +31,14 @@ optparse = OptionParser.new { |opts|
         cmdlineopts[:presfile] = opt
     end
 
+    opts.on("-o", "--output DIRECTORY", "Output directory to place generated files in.") do |opt|
+        cmdlineopts[:output] = opt
+    end
+
+    opts.on("-n", "--no-cache", "Don't cache template content") do
+        cmdlineopts[:nocache] = true
+    end
+
     opts.on("-d", "--debug", "Display debugging messages") do
         cmdlineopts[:debug] = true
     end
@@ -58,6 +66,7 @@ config ||= YAML.load_file(File.expand_path('../courseware.yaml')) rescue {}
 config.merge!(cmdlineopts)
 # finally, apply defaults to any unset options
 config[:templates]            ||= 'git@github.com:puppetlabs/courseware-templates.git'
+config[:nocache]              ||= false
 config[:cachedir]             ||= '~/.courseware'
 config[:stylesheet]           ||= 'courseware.css'
 config[:renderer]             ||= :wkhtmltopdf

--- a/lib/courseware.rb
+++ b/lib/courseware.rb
@@ -19,8 +19,8 @@ class Courseware
       @manager    = Courseware::Manager.new(config, @repository)
     else
       require 'courseware/dummy'
-      @repository = Courseware::Dummy.new
-      @manager    = Courseware::Dummy.new
+      @repository = Courseware::Dummy.new(config)
+      @manager    = Courseware::Dummy.new(config)
       $logger.debug "Running outside a valid git repository."
     end
   end

--- a/lib/courseware/cache.rb
+++ b/lib/courseware/cache.rb
@@ -4,8 +4,10 @@ class Courseware::Cache
   def initialize(config)
     @config = config
 
-    clone
-    update
+    unless @config[:nocache]
+      clone
+      update
+    end
   end
 
   def clone

--- a/lib/courseware/dummy.rb
+++ b/lib/courseware/dummy.rb
@@ -1,4 +1,21 @@
 class Courseware::Dummy
+  attr_reader :coursename, :prefix
+
+  def initialize(config, repository=nil, generator=nil, printer=nil)
+    @config     = config
+
+    showoff     = Courseware.parse_showoff(@config[:presfile])
+    @coursename = showoff['name']
+    @prefix     = showoff['name'].gsub(' ', '_')
+    @sections   = showoff['sections']
+    @password   = showoff['key']
+    @current    = showoff['courseware_release']
+  end
+
+  def current(prefix)
+    @current
+  end
+
   def method_missing(meth, *args, &block)
     raise "Cannot call #{meth} without a working courseware repository"
   end

--- a/lib/courseware/repository.rb
+++ b/lib/courseware/repository.rb
@@ -3,9 +3,10 @@ require 'rubygems'
 class Courseware::Repository
 
   def initialize(config)
-    raise 'This is not a courseware repository' unless Courseware::Repository.repository?
     @config = config
+    return if @config[:nocache]
 
+    raise 'This is not a courseware repository' unless Courseware::Repository.repository?
     configure_courseware
   end
 

--- a/lib/courseware/version.rb
+++ b/lib/courseware/version.rb
@@ -1,4 +1,4 @@
 class Courseware
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end
 


### PR DESCRIPTION
There were several assumptions we (I) made when designing the courseware
manager that are not true when running it headless on the master. This
allows us to skip over those assumptions and generate PDF files via the
profile class.

TRAINTECH-855 #time 3h