### PR TITLE
Add named section support

### DIFF
--- a/lib/courseware/manager/validators.rb
+++ b/lib/courseware/manager/validators.rb
@@ -32,7 +32,8 @@ class Courseware::Manager
     sections = @sections.dup
 
     # This seems backwards, but we do it this way to get a case sensitive match
-    Dir.glob('**/*.md') do |file|
+    # http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob -- Baby jesus is crying.
+    Dir.glob("**{,/*/**}/*.md") do |file|
       sections.delete(file)
     end
     return if sections.empty?

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -90,12 +90,20 @@ class Courseware
   # TODO: I'm not happy with this being here, but I don't see a better place for it just now
   def self.parse_showoff(filename)
     showoff    = JSON.parse(File.read(filename))
-    sections   = showoff['sections'].map do |entry|
-      next entry if entry.is_a? String
-      next nil unless entry.is_a? Hash
-      next nil unless entry.include? 'include'
+    sections   = showoff['sections'].map do |entry, section|
+      next entry if entry.is_a? String and section.nil?
 
-      file = entry['include']
+      if entry.is_a? Hash
+        file = entry['include']
+      else
+        file = section
+      end
+
+      unless file
+        puts "Malformed entry: #{entry.inspect} - #{section.inspect}"
+        next nil
+      end
+
       path = File.dirname(file)
       data = JSON.parse(File.read(file))
 


### PR DESCRIPTION
Now that `showoff.json` is simplifying to a hash, the `validate` action
didn't parse it properly. This restores the proper behaviour.

TRAINTECH-1000 #resolved #time 1h