### PR TITLE
(TRAINTECH-1174) Do not accept blank as confirmed

### DIFF
--- a/lib/courseware/manager.rb
+++ b/lib/courseware/manager.rb
@@ -61,7 +61,7 @@ class Courseware::Manager
     Courseware.bailout?('Abort now if the commit message displayed is not what you expected.')
     build_pdfs(version)
     point_of_no_return
-    Courseware.bailout?('Please inspect the generated PDF files and abort if corrections must be made.') do
+    Courseware.bailout?('Please inspect the generated PDF files and abort if corrections must be made.', true) do
       @repository.discard(@config[:stylesheet])
     end
 

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -37,7 +37,7 @@ class Courseware
 
   def self.bailout?(message)
     print "#{message} Continue? [Y/n]: "
-    unless [ 'y', 'yes', '' ].include? STDIN.gets.strip.downcase
+    unless [ 'y', 'yes' ].include? STDIN.gets.strip.downcase
       if block_given?
         yield
       end

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -35,9 +35,15 @@ class Courseware
     answers.include? STDIN.gets.strip.downcase
   end
 
-  def self.bailout?(message)
-    print "#{message} Continue? [Y/n]: "
-    unless [ 'y', 'yes' ].include? STDIN.gets.strip.downcase
+  def self.bailout?(message, default=false)
+    if default
+      print "#{message} Continue? ['y/N']: " : 
+      options = ['y', 'yes']
+    else
+      print "#{message} Continue? ['Y/n']: "
+      options = [ 'y', 'yes', '']
+    end
+    unless options.include? STDIN.gets.strip.downcase
       if block_given?
         yield
       end

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -35,8 +35,8 @@ class Courseware
     answers.include? STDIN.gets.strip.downcase
   end
 
-  def self.bailout?(message, default=false)
-    if default
+  def self.bailout?(message, required=false)
+    if required
       print "#{message} Continue? ['y/N']: " : 
       options = ['y', 'yes']
     else


### PR DESCRIPTION
TRAINTECH-1174 #resolved #time 10m
Removed the blank option from bailout function.  This means that a
 user must enter y or yes to confirm a next step.