### PR TITLE
(TRAINTECH-1155) Release-Notes Naming Expanded

### DIFF
--- a/lib/courseware/manager.rb
+++ b/lib/courseware/manager.rb
@@ -55,17 +55,7 @@ class Courseware::Manager
     version = Courseware.increment(@repository.current(@coursename), type)
     Courseware.bailout?("Building a release for #{@coursename} version #{version}.")
 
-    rfiles = Dir.glob("Release-Notes*")
-    rnotes = false
-
-    for rfile in rfiles
-      if Courseware.grep(version, rfile)
-        rnotes = true
-        break
-      end
-    end
-
-    raise "Release notes not updated for #{version}" unless rnotes
+    raise "Release notes not updated for #{version}" if Dir.glob('Release-Notes*').select { |path| Courseware.grep(version, path) }.empty?
 
     Courseware.dialog('Last Repository Commit', @repository.last_commit)
     Courseware.bailout?('Abort now if the commit message displayed is not what you expected.')

--- a/lib/courseware/manager.rb
+++ b/lib/courseware/manager.rb
@@ -55,7 +55,17 @@ class Courseware::Manager
     version = Courseware.increment(@repository.current(@coursename), type)
     Courseware.bailout?("Building a release for #{@coursename} version #{version}.")
 
-    raise "Release notes not updated for #{version}" unless Courseware.grep(version, 'Release-Notes.md')
+    rfiles = Dir.glob("Release-Notes*")
+    rnotes = false
+
+    for rfile in rfiles
+      if Courseware.grep(version, rfile)
+        rnotes = true
+        break
+      end
+    end
+
+    raise "Release notes not updated for #{version}" unless rnotes
 
     Courseware.dialog('Last Repository Commit', @repository.last_commit)
     Courseware.bailout?('Abort now if the commit message displayed is not what you expected.')


### PR DESCRIPTION
TRAINTECH-1155 #resolved #time 30m
The check for new release notes was previously hardcoded to look
 for "Release-notes.md".  This gives us the option to create
 multiple release-notes files.