### PR TITLE
More robust printing options

### DIFF
--- a/bin/courseware
+++ b/bin/courseware
@@ -39,6 +39,14 @@ optparse = OptionParser.new { |opts|
         cmdlineopts[:nocache] = true
     end
 
+    opts.on("-e ID", "--event-id ID", "Event ID to use for generated PDF files") do |opt|
+        cmdlineopts[:event_id] = opt
+    end
+
+    opts.on("-k KEY", "--key KEY", "Key to encrypt PDF files with") do |opt|
+        cmdlineopts[:key] = opt
+    end
+
     opts.on("-d", "--debug", "Display debugging messages") do
         cmdlineopts[:debug] = true
     end

--- a/lib/courseware/printer.rb
+++ b/lib/courseware/printer.rb
@@ -16,13 +16,23 @@ class Courseware::Printer
 
     if @config[:pdf][:watermark]
       showoff   = Courseware.parse_showoff(@config[:presfile])
+      default   = @event_id[/-?(\w*)$/, 1] rescue nil
 
-      @event_id = showoff['event_id'] || Courseware.question('Enter the Event ID:')
-      @password = showoff['key']      || Courseware.question('Enter desired password:', (@event_id[/-?(\w*)$/, 1] rescue nil))
+      @event_id = showoff['event_id'] || @config[:event_id] || Courseware.question('Enter the Event ID:')
+      @password = showoff['key']      || @config[:key]      || Courseware.question('Enter desired password:', default)
 
       if @config[:nocache]
-        @watermark_style = File.join('_support', 'watermark.css')
-        @watermark_pdf   = File.join('_support', 'watermark.pdf')
+        # Find the '_support' directory, up to three levels up
+        # This allows some flexibility in how the courseware repository is laid out
+        path = '_support'
+        3.times do
+          break if File.exist?(path)
+          path = File.join('..', path)
+        end
+        raise "No support files found" unless File.directory?(path)
+
+        @watermark_style = File.join(path, 'watermark.css')
+        @watermark_pdf   = File.join(path, 'watermark.pdf')
       else
         @watermark_style = File.join(@config[:cachedir], 'templates', 'watermark.css')
         @watermark_pdf   = File.join(@config[:cachedir], 'templates', 'watermark.pdf')


### PR DESCRIPTION
This adds command line arguments to pass event ID and PDF key. It also
performs a quick resolution of the `_support` directory so that we don't
have to be so rigid in how the repo is laid out.

TRAINTECH-1267 #resolved #time 30m