### PR TITLE
(maint) loosened overly restrictive dependency

### DIFF
--- a/puppet-courseware-manager.gemspec
+++ b/puppet-courseware-manager.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("doc/**/*")
 
   s.add_runtime_dependency  "mdl",       '~> 0.2'
-  s.add_runtime_dependency  "showoff",   '~> 0.18.2'
+  s.add_runtime_dependency  "showoff",   '~> 0.18'
   s.add_runtime_dependency  "word_wrap", '~> 1.0'
 
   s.description       = <<-desc


### PR DESCRIPTION
The twiddle-wakka matches up to the next release. So `~> 0.18.2` matches `0.18.9` but not `0.19.0`. Dropping it to `~> 0.18` will match up to but not include `1.0`