### PR TITLE
Releases now encompass all variants of a course

### DIFF
--- a/bin/courseware
+++ b/bin/courseware
@@ -99,6 +99,9 @@ config[:release][:links]      ||= []
 if ARGV == ['validate', 'obsolete']
   config[:presfile] ||= :none
 
+elsif ARGV.first == 'release'
+  config[:presfile] ||= Courseware.choose_variant(:exhaustive => true)
+
 elsif ARGV.first == 'compose'
   config[:presfile] ||= 'showoff.json'
 

--- a/lib/courseware.rb
+++ b/lib/courseware.rb
@@ -12,7 +12,6 @@ class Courseware
     @configfile = configfile
     @cache      = Courseware::Cache.new(config)
     @generator  = Courseware::Generator.new(config)
-    @composer   = Courseware::Composer.new(config)
 
     if Courseware::Repository.repository?
       @repository = Courseware::Repository.new(config)
@@ -149,11 +148,11 @@ class Courseware
   end
 
   def compose(subject)
-    @composer.build(subject)
+    Courseware::Composer.new(@config).build(subject)
   end
 
   def package(subject)
-    @composer.package(subject)
+    Courseware::Composer.new(@config).package(subject)
   end
 
   def debug

--- a/lib/courseware/printer.rb
+++ b/lib/courseware/printer.rb
@@ -54,25 +54,25 @@ class Courseware::Printer
   end
 
   def handouts
-    $logger.info "Generating handouts pdf for #{@course} #{@version}..."
+    $logger.info "Generating handouts pdf for #{@variant} #{@course} #{@version}..."
 
     generate_pdf(:print)
   end
 
   def exercises
-    $logger.info "Generating exercise guide pdf for #{@course} #{@version}..."
+    $logger.info "Generating exercise guide pdf for #{@variant} #{@course} #{@version}..."
 
     generate_pdf(:exercises)
   end
 
   def solutions
-    $logger.info "Generating solutions guide pdf for #{@course} #{@version}..."
+    $logger.info "Generating solutions guide pdf for #{@variant} #{@course} #{@version}..."
 
     generate_pdf(:solutions)
   end
 
   def guide
-    $logger.info "Generating instructor guide pdf for #{@course} #{@version}..."
+    $logger.info "Generating instructor guide pdf for #{@variant} #{@course} #{@version}..."
 
     generate_pdf(:guide)
   end

--- a/lib/courseware/repository.rb
+++ b/lib/courseware/repository.rb
@@ -105,8 +105,10 @@ class Courseware::Repository
   end
 
   def releasenotes(last, version)
-    # get used files from showoff and combine them into a single array
-    used = JSON.parse(`showoff info --json`).values.reduce(:+)
+    # get used files from each variant and combine them into a single array
+    used = Array(@config[:presfile]).inject([]) do |acc, variant|
+      acc + JSON.parse(`showoff info -jf #{variant}`).values.reduce(:+)
+    end.uniq
     logs = `git log --name-only --no-merges --pretty="format:* (%h) %s [%aN]" #{last}..HEAD`
     curr = nil
     keep = []

--- a/lib/courseware/utils.rb
+++ b/lib/courseware/utils.rb
@@ -87,10 +87,11 @@ class Courseware
     ans
   end
 
-  def self.choose_variant
+  def self.choose_variant(opts = {})
     variants = Dir.glob('*.json')
     return :none if variants.empty?
     return 'showoff.json' if variants == ['showoff.json']
+    return variants if opts[:exhaustive]
 
     maxlen = variants.max { |x,y| x.size <=> y.size }.size - 4 # accomodate for the extension we're stripping
 


### PR DESCRIPTION
This changes the `release` and `release notes` tasks to consider all
variants. For example, build PDF files for each variant and consolidate
release notes from all variants.

TRAINTECH-1566 #resolved #time 3h